### PR TITLE
Аdd playbook to install dokcer

### DIFF
--- a/playbooks/install_docker.yml
+++ b/playbooks/install_docker.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install Docker
-  hosts: azure_vm
+  hosts: 127.0.0.1
+  connection: local
   become: true
   tasks:
     - name: Update apt repositories


### PR DESCRIPTION
This is ansible playbook to install Docker
 to run the playbook use the command
`ansible-playbook  install_docker.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated playbook to install and configure Docker on target hosts, including user group setup for Docker access without sudo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->