### PR TITLE
add playbook to install mssql

### DIFF
--- a/playbooks/install_mssql.yml
+++ b/playbooks/install_mssql.yml
@@ -1,0 +1,46 @@
+---
+- name: Install SQL Server 2022 on Ubuntu 22.04 with automatic setup
+  hosts: db_servers
+  become: true
+
+  vars:
+    sa_password: "" 
+    mssql_edition: "Developer"          
+
+  tasks:
+    - name: Add Microsoft GPG key
+      apt_key:
+        url: https://packages.microsoft.com/keys/microsoft.asc
+        state: present
+
+    - name: Add Microsoft SQL Server repository
+      apt_repository:
+        repo: deb [arch=amd64] https://packages.microsoft.com/ubuntu/22.04/prod jammy main
+        state: present
+        filename: mssql-server
+
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+
+    - name: Install Microsoft SQL Server package
+      apt:
+        name: mssql-server
+        state: present
+
+    - name: Run mssql-conf with environment variables (non-interactive setup)
+      shell: >
+        MSSQL_PID={{ mssql_edition }}
+        MSSQL_SA_PASSWORD="{{ sa_password }}"
+        MSSQL_TCP_ENABLED=1
+        ACCEPT_EULA=Y
+        /opt/mssql/bin/mssql-conf -n setup
+      args:
+        creates: /var/opt/mssql/mssql.conf
+
+    - name: Enable and start SQL Server service
+      systemd:
+        name: mssql-server
+        enabled: yes
+        state: started
+


### PR DESCRIPTION
Added playbook to install mssql

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated installation and setup of Microsoft SQL Server 2022 on Ubuntu 22.04 servers using a new playbook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->